### PR TITLE
Fix API key initialization

### DIFF
--- a/services/classifier.py
+++ b/services/classifier.py
@@ -42,9 +42,12 @@ def extract_title_with_llm(text: str) -> list[MediaItem] | ErrorResponse:
 
         response = llm.invoke([HumanMessage(content=prompt)])
 
-        content = response.content
+        content = getattr(response, "content", response)
 
-        cleaned_content = content.strip("```").lstrip("json")
+        if not isinstance(content, str):
+            content = str(content)
+
+        cleaned_content = content.strip("`").lstrip("json").strip()
 
         try:
             return json.loads(cleaned_content)

--- a/services/llm_client.py
+++ b/services/llm_client.py
@@ -1,7 +1,8 @@
 import os
+from pydantic import SecretStr
 from langchain_openai import ChatOpenAI
 
-OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
+OPENROUTER_API_KEY: SecretStr = SecretStr(os.getenv("OPENROUTER_API_KEY", ""))
 MODEL = "google/gemma-3n-e4b-it:free"
 
 # Shared ChatOpenAI instance for reuse across services


### PR DESCRIPTION
## Summary
- simplify SecretStr usage for OpenRouter API key
- keep classifier response parsing tweaks

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848224e5330832aabac5e4afc3a1912