### PR TITLE
feat: implement fuzzy search on book metadata

### DIFF
--- a/services/metadata.py
+++ b/services/metadata.py
@@ -1,5 +1,4 @@
 import os
-from typing import Any
 import requests
 import re
 from rapidfuzz import fuzz, process
@@ -106,9 +105,14 @@ def fetch_tv_metadata(title: str, year: int | None = None) -> dict[str, str]:
         return {"error": f"Metadata lookup failed: {str(e)}"}
 
 
-def get_book_title(item: Any) -> str:
-    title = item.get("volumeInfo", {}).get("title", "")
-    return title if isinstance(title, str) else ""
+def get_book_title(item: object) -> str:
+    if isinstance(item, dict) and "volumeInfo" in item and "title" in item["volumeInfo"]:
+        return str(item["volumeInfo"]["title"])
+
+    if isinstance(item, str):
+        return item
+
+    return ""
 
 def fetch_book_metadata(title: str, author: str | None = None) -> dict[str, str]:
     try:
@@ -122,7 +126,6 @@ def fetch_book_metadata(title: str, author: str | None = None) -> dict[str, str]
         items = res.get("items", [])
 
         if items:
-            # might need to do fuzzy matching here as well
             best_match = process.extractOne(
                 query=title, choices=items, processor=get_book_title, scorer=fuzz.WRatio
             )


### PR DESCRIPTION
Sometimes the Google Book API doesn't return the intended book as the first element, for instance with this input
```
https://www.googleapis.com/books/v1/volumes?q=House%20of%20Leaves
```
The resulting data looks like this
```
"items": [
    {
      "kind": "books#volume",
      "id": "wc0e8lUPwB0C",
      "etag": "6yrfXO7zyJE",
      "selfLink": "https://www.googleapis.com/books/v1/volumes/wc0e8lUPwB0C",
      "volumeInfo": {
        "title": "Red Leaves: Tale of Murder and Suicides",
        "authors": [
          "Thomas H.Cook"
        ],
        "publisher": "Zahra Publishing House",
        "publishedDate": "2006",
        "industryIdentifiers": [
          {
            "type": "ISBN_10",
            "identifier": "9793972092"
          },
          {
            "type": "ISBN_13",
            "identifier": "9789793972091"
          }
        ],
        "readingModes": {
          "text": false,
          "image": true
        },
        "pageCount": 428,
        "printType": "BOOK",
        "categories": [
          "Babysitters"
        ],
        "averageRating": 4,
        "ratingsCount": 1,
        "maturityRating": "NOT_MATURE",
        "allowAnonLogging": false,
        "contentVersion": "0.3.5.0.preview.1",
        "panelizationSummary": {
          "containsEpubBubbles": false,
          "containsImageBubbles": false
        },
        "imageLinks": {
          "smallThumbnail": "http://books.google.com/books/content?id=wc0e8lUPwB0C&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
          "thumbnail": "http://books.google.com/books/content?id=wc0e8lUPwB0C&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
        },
        "language": "en",
        "previewLink": "http://books.google.co.id/books?id=wc0e8lUPwB0C&printsec=frontcover&dq=House+of+Leaves&hl=&cd=1&source=gbs_api",
        "infoLink": "http://books.google.co.id/books?id=wc0e8lUPwB0C&dq=House+of+Leaves&hl=&source=gbs_api",
        "canonicalVolumeLink": "https://books.google.com/books/about/Red_Leaves_Tale_of_Murder_and_Suicides.html?hl=&id=wc0e8lUPwB0C"
      },
      "saleInfo": {
        "country": "ID",
        "saleability": "NOT_FOR_SALE",
        "isEbook": false
      },
      "accessInfo": {
        "country": "ID",
        "viewability": "PARTIAL",
        "embeddable": true,
        "publicDomain": false,
        "textToSpeechPermission": "ALLOWED",
        "epub": {
          "isAvailable": false
        },
        "pdf": {
          "isAvailable": true,
          "acsTokenLink": "http://books.google.co.id/books/download/Red_Leaves_Tale_of_Murder_and_Suicides-sample-pdf.acsm?id=wc0e8lUPwB0C&format=pdf&output=acs4_fulfillment_token&dl_type=sample&source=gbs_api"
        },
        "webReaderLink": "http://play.google.com/books/reader?id=wc0e8lUPwB0C&hl=&source=gbs_api",
        "accessViewStatus": "SAMPLE",
        "quoteSharingAllowed": false
      }
    },
    {
      "kind": "books#volume",
      "id": "o6NzGNODRjkC",
      "etag": "+l+R84a5RF8",
      "selfLink": "https://www.googleapis.com/books/v1/volumes/o6NzGNODRjkC",
      "volumeInfo": {
        "title": "House of Leaves",
        "subtitle": "The Remastered Full-Color Edition",
        "authors": [
          "Mark Z. Danielewski"
        ],
        "publisher": "Pantheon",
        "publishedDate": "2000",
        "description": "THE MIND-BENDING CULT CLASSIC ABOUT A HOUSE THAT’S LARGER ON THE INSIDE THAN ON THE OUTSIDE • A masterpiece of horror and an astonishingly immersive, maze-like reading experience that redefines the boundaries of a novel. ''Simultaneously reads like a thriller and like a strange, dreamlike excursion into the subconscious.\" —Michiko Kakutani, The New York Times \"Thrillingly alive, sublimely creepy, distressingly scary, breathtakingly intelligent—it renders most other fiction meaningless.\" —Bret Easton Ellis, bestselling author of American Psycho “This demonically brilliant book is impossible to ignore.” —Jonathan Lethem, award-winning author of Motherless Brooklyn One of The Atlantic’s Great American Novels of the Past 100 Years Years ago, when House of Leaves was first being passed around, it was nothing more than a badly bundled heap of paper, parts of which would occasionally surface on the Internet. No one could have anticipated the small but devoted following this terrifying story would soon command. Starting with an odd assortment of marginalized youth—musicians, tattoo artists, programmers, strippers, environmentalists, and adrenaline junkies—the book eventually made its way into the hands of older generations, who not only found themselves in those strangely arranged pages but also discovered a way back into the lives of their estranged children. Now made available in book form, complete with the original colored words, vertical footnotes, and second and third appendices, the story remains unchanged. Similarly, the cultural fascination with House of Leaves remains as fervent and as imaginative as ever. The novel has gone on to inspire doctorate-level courses and masters theses, cultural phenomena like the online urban legend of “the backrooms,” and incredible works of art in entirely unrealted mediums from music to video games. Neither Pulitzer Prize-winning photojournalist Will Navidson nor his companion Karen Green was prepared to face the consequences of the impossibility of their new home, until the day their two little children wandered off and their voices eerily began to return another story—of creature darkness, of an ever-growing abyss behind a closet door, and of that unholy growl which soon enough would tear through their walls and consume all their dreams.",
        "industryIdentifiers": [
          {
            "type": "ISBN_10",
            "identifier": "0375703764"
          },
          {
            "type": "ISBN_13",
            "identifier": "9780375703768"
          }
        ],
        "readingModes": {
          "text": false,
          "image": false
        },
        "pageCount": 742,
        "printType": "BOOK",
        "categories": [
          "Fiction"
        ],
        "averageRating": 4.5,
        "ratingsCount": 35,
        "maturityRating": "NOT_MATURE",
        "allowAnonLogging": false,
        "contentVersion": "1.5.2.0.preview.0",
        "panelizationSummary": {
          "containsEpubBubbles": false,
          "containsImageBubbles": false
        },
        "imageLinks": {
          "smallThumbnail": "http://books.google.com/books/content?id=o6NzGNODRjkC&printsec=frontcover&img=1&zoom=5&source=gbs_api",
          "thumbnail": "http://books.google.com/books/content?id=o6NzGNODRjkC&printsec=frontcover&img=1&zoom=1&source=gbs_api"
        },
        "language": "en",
        "previewLink": "http://books.google.co.id/books?id=o6NzGNODRjkC&q=House+of+Leaves&dq=House+of+Leaves&hl=&cd=2&source=gbs_api",
        "infoLink": "http://books.google.co.id/books?id=o6NzGNODRjkC&dq=House+of+Leaves&hl=&source=gbs_api",
        "canonicalVolumeLink": "https://books.google.com/books/about/House_of_Leaves.html?hl=&id=o6NzGNODRjkC"
      },
      "saleInfo": {
        "country": "ID",
        "saleability": "NOT_FOR_SALE",
        "isEbook": false
      },
      "accessInfo": {
        "country": "ID",
        "viewability": "NO_PAGES",
        "embeddable": false,
        "publicDomain": false,
        "textToSpeechPermission": "ALLOWED",
        "epub": {
          "isAvailable": false
        },
        "pdf": {
          "isAvailable": false
        },
        "webReaderLink": "http://play.google.com/books/reader?id=o6NzGNODRjkC&hl=&source=gbs_api",
        "accessViewStatus": "NONE",
        "quoteSharingAllowed": false
      },
      "searchInfo": {
        "textSnippet": "No one could have anticipated the small but devoted following this terrifying story would soon command."
      }
    },
```

"House of Leaves" is the second element (somehow) rather than the first