### PR TITLE
Implement public API rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Metadata lookups first query the Wikipedia search API to fix misspellings. The r
    OPENROUTER_API_KEY=<your-openrouter-api-key>
    TMDB_API_KEY=<your-tmdb-api-key>
    GOOGLE_VISION_API_KEY=<your-google-vision-api-key>
+   MEDIA_EXTRACTOR_PUBLIC_API_KEY=<optional-public-api-key>
    ```
 4. **Start the server** using Uvicorn:
    ```bash
@@ -40,6 +41,8 @@ Form fields:
 | `query` | string | Additional text query (optional) |
 
 If both fields are supplied, the text extracted from the file is concatenated with the query before being processed.
+
+Requests authenticated with the optional public API key are limited to **2** requests every **15 minutes**. Exceeding this limit will return a `429 Too Many Requests` error.
 
 ## Roadmap
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,4 +1,6 @@
 import os
+import time
+from collections import deque
 from fastapi import Depends, HTTPException, status
 from fastapi.security.api_key import APIKeyHeader
 
@@ -14,9 +16,34 @@ def get_api_key() -> str:
 
 api_key_header = APIKeyHeader(name="X-API-KEY", auto_error=False)
 
+PUBLIC_API_KEY = os.getenv("MEDIA_EXTRACTOR_PUBLIC_API_KEY")
+_public_key_requests: deque[float] = deque()
+RATE_LIMIT_REQUESTS = 2
+RATE_LIMIT_WINDOW = 15 * 60  # 15 minutes in seconds
+
+
+def _is_public_key_limited() -> bool:
+    """Return True if the public key has exceeded the rate limit."""
+    now = time.monotonic()
+    while _public_key_requests and now - _public_key_requests[0] > RATE_LIMIT_WINDOW:
+        _public_key_requests.popleft()
+    if len(_public_key_requests) >= RATE_LIMIT_REQUESTS:
+        return True
+    _public_key_requests.append(now)
+    return False
+
 
 async def authorize(api_key: str = Depends(api_key_header)) -> None:
     expected_key = get_api_key()
+
+    if PUBLIC_API_KEY and api_key == PUBLIC_API_KEY:
+        if _is_public_key_limited():
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="Rate limit exceeded: 2 requests per 15 minutes.",
+            )
+        return
+
     if api_key != expected_key:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,


### PR DESCRIPTION
## Summary
- add a rate limit for requests that use the public API key
- document the new `MEDIA_EXTRACTOR_PUBLIC_API_KEY` in the README

## Testing
- `pre-commit run --files app/auth.py README.md`

------
https://chatgpt.com/codex/tasks/task_e_686d2b86bcc0832a8d75d4c2fbb0b10f